### PR TITLE
Add `no_merge` option to `update` cmd

### DIFF
--- a/src/subcmd/deposit_sol.rs
+++ b/src/subcmd/deposit_sol.rs
@@ -103,6 +103,7 @@ impl DepositSolArgs {
             validator_list_entries: &validators,
             fee_limit_cb: args.fee_limit_cb,
             ctrl: UpdateCtrl::IfNeeded,
+            no_merge: false,
         })
         .await;
 

--- a/src/subcmd/deposit_stake.rs
+++ b/src/subcmd/deposit_stake.rs
@@ -199,6 +199,7 @@ impl DepositStakeArgs {
             validator_list_entries: &validators,
             fee_limit_cb: args.fee_limit_cb,
             ctrl: UpdateCtrl::IfNeeded,
+            no_merge: false,
         })
         .await;
 

--- a/src/subcmd/sync_validator_list.rs
+++ b/src/subcmd/sync_validator_list.rs
@@ -97,6 +97,7 @@ impl SyncValidatorListArgs {
             validator_list_entries: &old_validators,
             fee_limit_cb: args.fee_limit_cb,
             ctrl: UpdateCtrl::IfNeeded,
+            no_merge: false,
         })
         .await;
 

--- a/src/subcmd/update.rs
+++ b/src/subcmd/update.rs
@@ -29,6 +29,14 @@ pub struct UpdateArgs {
     pub ctrl: UpdateCtrl,
 
     #[arg(
+        long,
+        short,
+        help = "UpdateStakePoolBalance instruction's `no_merge` parameter",
+        default_value_t = false
+    )]
+    pub no_merge: bool,
+
+    #[arg(
         help = "Pubkey of the pool to update",
         value_parser = StringValueParser::new().try_map(|s| Pubkey::from_str(&s)),
     )]
@@ -37,7 +45,11 @@ pub struct UpdateArgs {
 
 impl UpdateArgs {
     pub async fn run(args: crate::Args) {
-        let Self { pool, ctrl } = match args.subcmd {
+        let Self {
+            pool,
+            ctrl,
+            no_merge,
+        } = match args.subcmd {
             Subcmd::Update(a) => a,
             _ => unreachable!(),
         };
@@ -74,6 +86,7 @@ impl UpdateArgs {
             validator_list_entries: &validators,
             fee_limit_cb: args.fee_limit_cb,
             ctrl,
+            no_merge,
         })
         .await;
     }

--- a/src/subcmd/withdraw_stake.rs
+++ b/src/subcmd/withdraw_stake.rs
@@ -212,6 +212,7 @@ impl WithdrawStakeArgs {
             validator_list_entries: &validators,
             fee_limit_cb: args.fee_limit_cb,
             ctrl: UpdateCtrl::IfNeeded,
+            no_merge: false,
         })
         .await;
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -52,6 +52,7 @@ pub struct UpdatePoolArgs<'a> {
     pub validator_list_entries: &'a [ValidatorStakeInfo],
     pub fee_limit_cb: u64,
     pub ctrl: UpdateCtrl,
+    pub no_merge: bool,
 }
 
 // ignores entries already updated for this epoch
@@ -66,6 +67,7 @@ pub async fn update_pool(
         validator_list_entries,
         fee_limit_cb,
         ctrl,
+        no_merge,
     }: UpdatePoolArgs<'_>,
 ) {
     let sp = StakePool::deserialize(&mut stake_pool.account.data.as_slice()).unwrap();
@@ -98,7 +100,7 @@ pub async fn update_pool(
                     chunk,
                     UpdateValidatorListBalanceIxArgs {
                         start_index: start_index.try_into().unwrap(),
-                        no_merge: false,
+                        no_merge,
                     },
                 )
                 .unwrap()];


### PR DESCRIPTION
Required to deal with special cases e.g. vsa was deactivatedeliquent'd previously but not removed and validator resumed voting so now you have an active tsa but inactive vsa that cant be merged